### PR TITLE
Enable mobile participants to join and roll via QR

### DIFF
--- a/ALCO_monopoly.html
+++ b/ALCO_monopoly.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>酒精大富翁 — v10</title>
+  <script src="https://unpkg.com/peerjs@1.5.2/dist/peerjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
   <style>
     :root { --bg:#0f1116;--panel:#151a22;--tile:#1c2330;--text:#e6f0ff;--muted:#a9b6cc;--accent:#8ac6ff;
       --c-start:#F6C549; --b-start:#7a5a00; --g-start:linear-gradient(180deg,#6b4c00,#2a2209);
@@ -13,10 +15,11 @@
       --c-beer:#57E27A; --b-beer:#218c44; --g-beer:linear-gradient(180deg,#144d2b,#0d2816);
       --c-danger:#FF5E5E; --b-danger:#a33a3a; --g-danger:linear-gradient(180deg,#4a1010,#2a0808);
     }
-    html,body{height:100%;margin:0;background:#0e1420;color:var(--text);font-family:ui-sans-serif,system-ui,"Segoe UI",Noto Sans,Arial;overflow:hidden}
+    html,body{height:100%;margin:0;background:#0e1420;color:var(--text);font-family:ui-sans-serif,system-ui,"Segoe UI",Noto Sans,Arial;overflow:auto}
 
-    .app{height:100%;display:grid;grid-template-rows:56px 1fr;gap:8px;padding:10px}
+    .app{min-height:100%;display:grid;grid-template-rows:56px 1fr;gap:8px;padding:10px}
     .top{display:flex;align-items:center;justify-content:space-between;background:var(--panel);border-radius:12px;padding:0 10px}
+    .top .row{flex-wrap:wrap;justify-content:flex-end}
     .brand{display:flex;align-items:center;gap:10px;font-weight:800}
     .btn{background:#203049;border:1px solid #2e4161;color:var(--text);padding:8px 12px;border-radius:10px;cursor:pointer;font-weight:600}
     .btn:disabled{opacity:.5;cursor:not-allowed}
@@ -27,6 +30,23 @@
     .card{border:1px solid #324666;border-radius:12px;padding:10px;background:#0f1522}
     .list{display:grid;gap:8px}
     .row{display:flex;gap:8px;align-items:center}
+    .player-head{align-items:center;gap:10px}
+    .player-avatar{width:36px;height:36px;border-radius:50%;object-fit:cover;border:2px solid rgba(255,255,255,.2);box-shadow:0 0 0 2px rgba(0,0,0,.35)}
+    .player-dot{width:16px;height:16px;border-radius:999px;border:2px solid rgba(255,255,255,.7)}
+    .remote-tag{font-size:11px;color:var(--accent);margin-left:auto}
+    .remote-info{display:grid;gap:8px;text-align:center}
+    .remote-info canvas{margin:0 auto;border-radius:12px;background:#fff;padding:10px}
+    .link{color:var(--accent);word-break:break-all}
+    .copy-btn{align-self:center}
+
+    .client-pane{display:none;gap:10px;grid-template-columns:1fr;margin-bottom:20px}
+    .client-pane .card{background:rgba(15,22,36,.9)}
+    .client-status{font-size:14px}
+    .client-message{font-size:13px;color:var(--muted)}
+
+    .client-list{display:grid;gap:6px}
+    .client-list .item{display:flex;align-items:center;gap:10px;padding:6px 8px;border-radius:10px;background:rgba(26,36,56,.6)}
+    .client-list .item .player-avatar{width:32px;height:32px}
     input,select,textarea{background:#0f1624;border:1px solid #2c3f60;color:var(--text);border-radius:10px;padding:8px}
 
     .meter{background:#0b1220;border-radius:8px;border:1px solid #2b3952;height:8px;width:120px;position:relative;overflow:hidden}
@@ -83,6 +103,28 @@
     /* 放大翻卡字體 */
     #tileDesc{font-size:18px;line-height:1.7}
     #cardText{font-size:22px;line-height:1.6}
+
+    .client-mode .top .row{display:none}
+    .client-mode .grid,.client-mode .hud,.client-mode #remoteJoinCard{display:none}
+    .client-mode .app{grid-template-rows:auto 1fr;padding:16px}
+    .client-mode .client-pane{display:grid}
+
+    @media (max-width:1200px){
+      .grid{grid-template-columns:1fr;grid-template-rows:auto auto auto}
+      .hud{position:static;right:auto;bottom:auto}
+      .app{grid-template-rows:auto auto 1fr}
+    }
+    @media (max-width:900px){
+      .board{width:100%;max-width:100%;aspect-ratio:1/1}
+      .board-wrap{padding-bottom:20px}
+    }
+    @media (max-width:768px){
+      .top{flex-direction:column;align-items:flex-start;padding:10px;gap:8px}
+      .top .row{width:100%;justify-content:flex-start}
+      .hud{width:100%}
+      .hud .panel{width:100%}
+      .app{gap:12px;padding:12px}
+    }
   </style>
 </head>
 <body>
@@ -106,6 +148,16 @@
           <div class="row"><input id="playerName" placeholder="玩家名稱，例如：小明"><button class="btn" id="addPlayer">加入</button></div>
           <div class="row"><button class="btn" id="quick2">快速 2 人</button><button class="btn" id="quick4">快速 4 人</button></div>
         </div>
+        <div class="card" id="remoteJoinCard">
+          <div class="title">手機加入</div>
+          <div class="remote-info">
+            <div>房間代碼：<b id="roomCode">—</b></div>
+            <canvas id="joinQR" width="200" height="200"></canvas>
+            <a class="link" id="joinUrl" target="_blank" rel="noopener"></a>
+            <button class="btn copy-btn" id="copyJoinLink" type="button">複製連結</button>
+            <div class="hint" id="remoteStatus">行動加入功能準備中…</div>
+          </div>
+        </div>
         <div class="list" id="playerList"></div>
       </div>
 
@@ -127,6 +179,44 @@
           <div class="card"><div class="title">遊戲卡池</div><div>Games：<span id="gamePeek"></span></div></div>
           <div class="card"><div class="title">事件紀錄</div><div class="log" id="log" style="max-height:40vh;overflow:auto;display:grid;gap:8px"></div></div>
         </div>
+      </div>
+    </div>
+
+    <div class="client-pane" id="clientPanel">
+      <div class="card">
+        <div class="title">連線狀態</div>
+        <div class="client-status" id="clientStatusText">等待連線…</div>
+        <div class="client-message" id="clientMessage"></div>
+        <div class="hint">房間代碼：<b id="clientRoomCode">—</b></div>
+      </div>
+      <div class="card" id="clientJoinCard">
+        <div class="title">加入遊戲</div>
+        <div class="list">
+          <input id="clientName" placeholder="輸入暱稱">
+          <input type="file" id="clientAvatar" accept="image/*">
+          <button class="btn" id="clientJoinBtn" type="button">加入</button>
+        </div>
+        <div class="hint">可上傳個人大頭貼（建議小於 1 MB）。</div>
+      </div>
+      <div class="card" id="clientControls" style="display:none">
+        <div class="title">行動操控</div>
+        <div class="list">
+          <div>輪到：<b id="clientTurnName">—</b></div>
+          <div>你目前位置：<span id="clientPos">—</span></div>
+          <div class="row" style="flex-wrap:wrap;gap:10px">
+            <button class="btn" id="clientRollBtn" type="button" disabled>擲骰</button>
+            <button class="btn" id="clientEndBtn" type="button" disabled>結束回合</button>
+          </div>
+          <div id="clientDiceInfo">骰子：—</div>
+        </div>
+      </div>
+      <div class="card" id="clientPlayersCard" style="display:none">
+        <div class="title">玩家</div>
+        <div class="client-list" id="clientPlayers"></div>
+      </div>
+      <div class="card" id="clientLogCard" style="display:none">
+        <div class="title">最新事件</div>
+        <div class="list" id="clientLog"></div>
       </div>
     </div>
 
@@ -216,6 +306,60 @@
     const $ = s => document.querySelector(s);
     const el = (t,c,h)=>{const e=document.createElement(t); if(c) e.className=c; if(h!==undefined) e.innerHTML=h; return e};
     const sample = arr => arr[Math.floor(Math.random()*arr.length)];
+    const params = new URLSearchParams(location.search);
+    const joinCodeParam = params.get('join');
+    const isClientMode = !!joinCodeParam;
+    const isHostMode = !isClientMode;
+    if(isClientMode) document.body.classList.add('client-mode');
+    let roomId = '';
+    const peerConnections = new Set();
+    const playerConnections = new Map();
+    let peerInstance = null;
+    let peerReady = false;
+    const MAX_LOG_HISTORY = 60;
+    const logHistory = [];
+    const clientContext = { peer:null, conn:null, joined:false, playerId:null };
+    let remoteStatusEl=null, joinUrlEl=null, roomCodeEl=null, joinQrCanvas=null, copyJoinBtn=null;
+    let clientStatusEl=null, clientMessageEl=null, clientJoinCardEl=null, clientControlsEl=null, clientPlayersEl=null, clientLogEl=null, clientRollBtn=null, clientEndBtn=null, clientTurnNameEl=null, clientPosEl=null, clientDiceInfoEl=null, clientPlayersCardEl=null, clientLogCardEl=null, clientJoinBtnEl=null, clientNameInputEl=null, clientAvatarInputEl=null;
+
+    function generateRoomId(){ return Math.random().toString(36).substring(2,8).toUpperCase(); }
+    function normalizeRoomId(code){ return (code||'').toString().trim().toLowerCase(); }
+
+    function updateRemoteStatus(){
+      if(!remoteStatusEl) return;
+      if(!peerInstance){ if(!remoteStatusEl.textContent) remoteStatusEl.textContent='行動加入功能準備中…'; return; }
+      const deviceCount = Array.from(peerConnections).filter(c=>c.open).length;
+      const joinedCount = playerConnections.size;
+      remoteStatusEl.textContent = `已連線裝置：${deviceCount} · 已加入玩家：${joinedCount}`;
+    }
+
+    function getPublicState(){
+      const active = state.players[state.turn] || null;
+      return {
+        roomId,
+        players: state.players.map(p=>({id:p.id,name:p.name,color:p.color,pos:p.pos,totalSips:p.totalSips,skip:p.skip,avatar:p.avatar||null,remote:!!p.remote})),
+        turn: state.turn,
+        waitingEnd: state.waitingEnd,
+        activePlayerId: active ? active.id : null,
+        dice: ($('#dice')||{textContent:'–'}).textContent,
+        logs: logHistory.slice(0,12)
+      };
+    }
+
+    function broadcastState(){
+      if(!isHostMode || !peerReady) return;
+      const payload = { type:'state', payload:getPublicState() };
+      peerConnections.forEach(conn=>{
+        if(conn.open){ try{ conn.send(payload); }catch(err){ console.warn('send state failed', err); } }
+      });
+    }
+
+    function syncState(){ if(isHostMode) broadcastState(); }
+
+    function sendToPlayer(id, data){
+      const conn = playerConnections.get(id);
+      if(conn && conn.open){ try{ conn.send(data); }catch(err){ console.warn('send message failed', err); } }
+    }
 
     // v10：在 v9（無公杯＋抽卡不再跳人）的基礎上，加入「遊戲卡池」並放大翻卡字體
     const DEFAULT = { tiles:[
@@ -313,28 +457,126 @@
 
     function indexToGrid(i){ if(i<N) return {r:0,c:i}; if(i<N+(N-1)) return {r:i-(N-1),c:N-1}; if(i<N+(N-1)+(N-1)) return {r:N-1,c:(N-1)-(i-(N+(N-1)))}; return {r:(N-1)-(i-(N+(N-1)+(N-1))),c:0}; }
 
-    function addPlayer(name){ if(!name) return; if(state.players.length>=20) return alert('最多 20 位玩家'); const color=COLORS[state.players.length%COLORS.length]; state.players.push({id:crypto.randomUUID(),name,color,pos:0,sips:0,totalSips:0,skip:false,buff:0,pawn:null}); renderPlayers(); placePawns(); log(`加入玩家：${name}`); if(state.players.length===1) refreshTurnInfo(); updateControls(); }
-    function removePlayer(id){ const i=state.players.findIndex(p=>p.id===id); if(i>=0){ const [p]=state.players.splice(i,1); log(`移除玩家：${p.name}`); renderPlayers(); placePawns(); refreshTurnInfo(); updateControls(); }}
-    function renderPlayers(){ const list=$('#playerList'); list.innerHTML=''; state.players.forEach((p,idx)=>{ const row=el('div',`card ${idx===state.turn?'active':''}`); const dot=el('div'); Object.assign(dot.style,{width:'16px',height:'16px',borderRadius:'999px',border:'2px solid rgba(255,255,255,.7)',background:p.color}); const head=el('div','row'); head.appendChild(dot); head.appendChild(el('div','',`<b>${p.name}</b>`)); const meta=el('div','',`<div style="font-size:12px;color:var(--muted)">位置 ${p.pos} · 總 ${p.totalSips} 口 ${p.skip?'·下回合跳過':''}</div>`); const m=el('div','meter'); const bar=el('span'); bar.style.width=Math.min(100,(p.sips*10))+'%'; m.appendChild(bar); const rm=el('button','btn','移除'); rm.onclick=()=>removePlayer(p.id); row.appendChild(head); row.appendChild(meta); row.appendChild(m); row.appendChild(rm); list.appendChild(row); }); }
+    function addPlayer(name, options={}){
+      name = (name||'').toString().trim();
+      if(!name) return null;
+      if(state.players.length>=20){ if(!options.silent) alert('最多 20 位玩家'); return null; }
+      const color=(options.color)||COLORS[state.players.length%COLORS.length];
+      const player={id:crypto.randomUUID(),name,color,pos:0,sips:0,totalSips:0,skip:false,buff:0,pawn:null,avatar:options.avatar||null,remote:!!options.remote,connectionId:options.connectionId||null};
+      state.players.push(player);
+      renderPlayers();
+      placePawns();
+      log(`加入玩家：${name}`);
+      if(state.players.length===1) refreshTurnInfo();
+      updateControls();
+      updateRemoteStatus();
+      syncState();
+      return player;
+    }
+    function removePlayer(id){
+      const i=state.players.findIndex(p=>p.id===id);
+      if(i>=0){
+        const [p]=state.players.splice(i,1);
+        if(p.remote){
+          const conn=playerConnections.get(p.id);
+          if(conn){
+            try{ conn.send({type:'removed'}); }catch(err){ console.warn(err); }
+            conn.playerId=null;
+          }
+          playerConnections.delete(p.id);
+        }
+        if(state.players.length===0){ state.turn=0; }
+        else if(state.turn>=state.players.length){ state.turn=state.turn%state.players.length; }
+        log(`移除玩家：${p.name}`);
+        renderPlayers();
+        placePawns();
+        refreshTurnInfo();
+        updateControls();
+        updateRemoteStatus();
+        syncState();
+      }
+    }
+    function renderPlayers(){
+      const list=$('#playerList');
+      if(!list) return;
+      list.innerHTML='';
+      state.players.forEach((p,idx)=>{
+        const row=el('div',`card ${idx===state.turn?'active':''}`);
+        const head=el('div','row player-head');
+        if(p.avatar){
+          const img=el('img','player-avatar');
+          img.src=p.avatar;
+          img.alt=p.name;
+          head.appendChild(img);
+        } else {
+          const dot=el('div','player-dot');
+          dot.style.background=p.color;
+          head.appendChild(dot);
+        }
+        head.appendChild(el('div','',`<b>${p.name}</b>`));
+        if(p.remote){ head.appendChild(el('span','remote-tag','手機連線')); }
+        const metaInfo=[`位置 ${p.pos}`,`總 ${p.totalSips} 口`];
+        if(p.skip) metaInfo.push('下回合跳過');
+        const meta=el('div','',`<div style="font-size:12px;color:var(--muted)">${metaInfo.join(' · ')}</div>`);
+        const m=el('div','meter');
+        const bar=el('span');
+        bar.style.width=Math.min(100,(p.sips*10))+'%';
+        m.appendChild(bar);
+        const rm=el('button','btn','移除');
+        rm.onclick=()=>removePlayer(p.id);
+        row.appendChild(head);
+        row.appendChild(meta);
+        row.appendChild(m);
+        row.appendChild(rm);
+        list.appendChild(row);
+      });
+    }
 
     function placePawns(){ document.querySelectorAll('.pawn').forEach(n=>n.remove()); state.players.forEach(p=>{ const tile=tileEls[p.pos]; if(!tile) return; const rect=tile.getBoundingClientRect(), boardRect=board.getBoundingClientRect(); const x=rect.left-boardRect.left+rect.width/2, y=rect.top-boardRect.top+rect.height/2; const pa=el('div','pawn'); pa.style.background=p.color; pa.style.transform=`translate(${x}px, ${y}px)`; board.appendChild(pa); p.pawn=pa; }); }
     window.addEventListener('resize', placePawns);
 
     function refreshTurnInfo(){ if(state.players.length===0){ $('#turnName').textContent='—'; $('#turnPos').textContent='0'; return;} const p=state.players[state.turn%state.players.length]; $('#turnName').textContent=p.name; $('#turnPos').textContent=p.pos; $('#guardHint').textContent = state.waitingEnd ? '請先「結束回合」再由下一位擲骰。' : ''; renderPlayers(); }
 
-    function nextTurn(){ if(state.players.length===0) return; const p=state.players[state.turn]; const delta=Math.max(0,p.sips+p.buff); if(delta>0) log(`${p.name} 喝掉 ${delta} 口。`); p.totalSips+=Math.max(0,delta); p.sips=0; p.buff=0; state.turn=(state.turn+1)%state.players.length; const n=state.players[state.turn]; if(n&&n.skip){ log(`${n.name} 跳過本回合。`); n.skip=false; state.turn=(state.turn+1)%state.players.length; } state.extra=false; state.waitingEnd=false; refreshTurnInfo(); updateControls(); }
+    function nextTurn(){
+      if(state.players.length===0) return;
+      const p=state.players[state.turn];
+      const delta=Math.max(0,p.sips+p.buff);
+      if(delta>0) log(`${p.name} 喝掉 ${delta} 口。`);
+      p.totalSips+=Math.max(0,delta);
+      p.sips=0; p.buff=0;
+      state.turn=(state.turn+1)%state.players.length;
+      const n=state.players[state.turn];
+      if(n&&n.skip){
+        log(`${n.name} 跳過本回合。`);
+        n.skip=false;
+        state.turn=(state.turn+1)%state.players.length;
+      }
+      state.extra=false;
+      state.waitingEnd=false;
+      refreshTurnInfo();
+      updateControls();
+      syncState();
+    }
 
     const H=[];
     function pushSnapshot(){ const snap={ turn: state.turn, waitingEnd: state.waitingEnd, chance: JSON.parse(JSON.stringify(state.chance)), destiny: JSON.parse(JSON.stringify(state.destiny)), game: JSON.parse(JSON.stringify(state.game)), players: state.players.map(p=>({name:p.name,color:p.color,pos:p.pos,sips:p.sips,totalSips:p.totalSips,skip:p.skip,buff:p.buff})) }; H.push(snap); updateControls(); }
     function undo(){ if(!H.length) return; const s=H.pop(); state.turn=s.turn; state.waitingEnd=s.waitingEnd; state.chance=s.chance; state.destiny=s.destiny; state.game=s.game; state.players.forEach((p,i)=>{ const d=s.players[i]; if(!d) return; p.pos=d.pos; p.sips=d.sips; p.totalSips=d.totalSips; p.skip=d.skip; p.buff=d.buff; }); placePawns(); renderPlayers(); refreshTurnInfo(); updateControls(); log('已回復到上一步'); }
 
     // 擲骰流程（保留 v9 的修正：等卡牌關閉後才進入換人）
-    function roll(){
-      if(state.players.length===0) return alert('請先加入玩家');
-      if(state.anim||state.moving) return;
-      if(state.waitingEnd){ alert('請先按「結束回合」，再由下一位擲骰。'); return; }
+    function roll(opts={}){
+      const fromRemote=opts.fromRemote;
+      const playerId=opts.playerId;
+      if(state.players.length===0){ if(!fromRemote) alert('請先加入玩家'); else if(playerId) sendToPlayer(playerId,{type:'info',message:'目前沒有玩家'}); return false; }
+      if(state.anim||state.moving) return false;
+      if(state.waitingEnd){
+        if(fromRemote&&playerId) sendToPlayer(playerId,{type:'info',message:'請先結束回合'});
+        else alert('請先按「結束回合」，再由下一位擲骰。');
+        return false;
+      }
+      const current=state.players[state.turn];
+      if(fromRemote && current && current.id!==playerId){ sendToPlayer(playerId,{type:'info',message:'尚未輪到你'}); return false; }
       pushSnapshot();
-      const p=state.players[state.turn]; let t=0; state.anim=true; $('#dice').classList.add('spin');
+      const p=current; let t=0; state.anim=true; $('#dice').classList.add('spin');
       const iv=setInterval(()=>{
         $('#dice').textContent=(Math.floor(Math.random()*6)+1);
         if(++t>10){
@@ -352,9 +594,11 @@
                 if($('#autoNext').checked){ nextTurn(); }
                 else { state.waitingEnd = true; refreshTurnInfo(); updateControls(); }
               }
+              syncState();
             });
         }
       },70);
+      return true;
     }
 
     function movePawn(player,steps){
@@ -366,7 +610,7 @@
           player.pos=(player.pos+dir+(4*(N-1)))%(4*(N-1));
           updatePawnPosition(player);
           moved++;
-          if(moved>=total){ clearInterval(timer); state.moving=false; res(); }
+          if(moved>=total){ clearInterval(timer); state.moving=false; syncState(); res(); }
         },220);
       });
     }
@@ -387,6 +631,7 @@
             default: if(t.desc) log(`${p.name}：${t.desc}`);
           }
           renderPlayers();
+          syncState();
           resolve();
         };
         showTileModal(t, after);
@@ -427,10 +672,340 @@
           fn(player,players,move,extraRoll,refreshPawn);
           log(`[${label}] ${card.text}`);
           renderPlayers();
+          syncState();
         }catch(e){ log(`卡牌執行錯誤：${e.message}`); }
       };
       $('#btnFlipCard').onclick=()=>{ $('#flipCard').classList.add('flipped'); ensure(); };
       $('#btnCardOk').onclick=()=>{ $('#modalCard').style.display='none'; onDone && onDone(); };
+    }
+
+    function setupHostNetworking(){
+      remoteStatusEl=$('#remoteStatus');
+      joinUrlEl=$('#joinUrl');
+      roomCodeEl=$('#roomCode');
+      joinQrCanvas=$('#joinQR');
+      copyJoinBtn=$('#copyJoinLink');
+      if(!remoteStatusEl) return;
+      if(!window.Peer){
+        remoteStatusEl.textContent='行動加入功能無法啟用（PeerJS 未載入）';
+        if(copyJoinBtn) copyJoinBtn.disabled=true;
+        return;
+      }
+      roomId = generateRoomId();
+      if(roomCodeEl) roomCodeEl.textContent=roomId;
+      const joinUrl=new URL(location.href);
+      joinUrl.search=`?join=${roomId}`;
+      joinUrl.hash='';
+      const joinUrlText=joinUrl.toString();
+      if(joinUrlEl){ joinUrlEl.textContent=joinUrlText; joinUrlEl.href=joinUrlText; }
+      if(copyJoinBtn){
+        copyJoinBtn.disabled=false;
+        copyJoinBtn.onclick=async()=>{
+          try{
+            await navigator.clipboard.writeText(joinUrlText);
+            copyJoinBtn.textContent='已複製';
+            setTimeout(()=>copyJoinBtn.textContent='複製連結',1600);
+          }catch(err){
+            alert('複製失敗，請手動複製網址');
+          }
+        };
+      }
+      if(joinQrCanvas && window.QRCode && QRCode.toCanvas){
+        QRCode.toCanvas(joinQrCanvas, joinUrlText,{width:200,margin:1},err=>{ if(err) console.warn(err); });
+      }
+      remoteStatusEl.textContent='正在建立房間…';
+      peerInstance = new Peer(`alco-${normalizeRoomId(roomId)}`,{debug:2});
+      peerInstance.on('open',()=>{ peerReady=true; remoteStatusEl.textContent='等待玩家加入'; updateRemoteStatus(); syncState(); });
+      peerInstance.on('connection',conn=>{
+        peerConnections.add(conn);
+        updateRemoteStatus();
+        const sendState=()=>{ if(conn.open){ try{ conn.send({type:'state',payload:getPublicState()}); }catch(err){ console.warn(err); } } };
+        if(conn.open) sendState(); else conn.on('open',()=>{ updateRemoteStatus(); sendState(); });
+        conn.on('data',data=>handleClientMessage(conn,data));
+        const cleanup=()=>handleClientDisconnect(conn);
+        conn.on('close',cleanup);
+        conn.on('error',cleanup);
+      });
+      peerInstance.on('error',err=>{
+        console.error(err);
+        remoteStatusEl.textContent='連線錯誤：'+(err&&err.message?err.message:err);
+      });
+    }
+
+    function handleClientMessage(conn,data){
+      if(!data||typeof data!=='object') return;
+      switch(data.type){
+        case 'join':{
+          const name=(data.name||'').toString().trim();
+          if(!name){ conn.send({type:'error',message:'請輸入暱稱'}); return; }
+          if(conn.playerId){
+            const player=state.players.find(p=>p.id===conn.playerId);
+            if(player){
+              player.avatar=data.avatar||player.avatar;
+              player.name=name;
+              renderPlayers();
+              refreshTurnInfo();
+              updateControls();
+              syncState();
+            }
+            return;
+          }
+          if(state.players.length>=20){ conn.send({type:'error',message:'玩家已達上限'}); return; }
+          const player=addPlayer(name,{avatar:data.avatar||null,remote:true,connectionId:conn.peer,silent:true});
+          if(!player){ conn.send({type:'error',message:'無法加入遊戲'}); return; }
+          playerConnections.set(player.id,conn);
+          conn.playerId=player.id;
+          conn.send({type:'joined',playerId:player.id});
+          updateRemoteStatus();
+          syncState();
+          break;
+        }
+        case 'roll':
+          if(conn.playerId) roll({fromRemote:true,playerId:conn.playerId});
+          break;
+        case 'endTurn':
+          if(conn.playerId){
+            const active=state.players[state.turn];
+            if(!active||active.id!==conn.playerId){ sendToPlayer(conn.playerId,{type:'info',message:'尚未輪到你'}); }
+            else if(!state.waitingEnd){ sendToPlayer(conn.playerId,{type:'info',message:'請先完成擲骰'}); }
+            else { nextTurn(); }
+          }
+          break;
+        default:
+          break;
+      }
+    }
+
+    function handleClientDisconnect(conn){
+      peerConnections.delete(conn);
+      if(conn.playerId){
+        const idx=state.players.findIndex(p=>p.id===conn.playerId);
+        if(idx>=0){
+          const player=state.players[idx];
+          if(player.remote){
+            state.players.splice(idx,1);
+            playerConnections.delete(player.id);
+            if(state.players.length===0) state.turn=0; else if(state.turn>=state.players.length) state.turn=state.turn%state.players.length;
+            log(`${player.name} 已離線並離開遊戲`);
+            renderPlayers();
+            placePawns();
+            refreshTurnInfo();
+            updateControls();
+            syncState();
+          }
+        }
+        conn.playerId=null;
+      }
+      updateRemoteStatus();
+    }
+
+    function setupClientNetworking(code){
+      clientStatusEl=$('#clientStatusText');
+      clientMessageEl=$('#clientMessage');
+      clientJoinCardEl=$('#clientJoinCard');
+      clientControlsEl=$('#clientControls');
+      clientPlayersEl=$('#clientPlayers');
+      clientLogEl=$('#clientLog');
+      clientRollBtn=$('#clientRollBtn');
+      clientEndBtn=$('#clientEndBtn');
+      clientTurnNameEl=$('#clientTurnName');
+      clientPosEl=$('#clientPos');
+      clientDiceInfoEl=$('#clientDiceInfo');
+      clientPlayersCardEl=$('#clientPlayersCard');
+      clientLogCardEl=$('#clientLogCard');
+      clientJoinBtnEl=$('#clientJoinBtn');
+      clientNameInputEl=$('#clientName');
+      clientAvatarInputEl=$('#clientAvatar');
+      if(clientControlsEl) clientControlsEl.style.display='none';
+      if(clientRollBtn) clientRollBtn.disabled=true;
+      if(clientEndBtn) clientEndBtn.disabled=true;
+      const roomLabel=$('#clientRoomCode');
+      roomId=(code||'').toString().toUpperCase();
+      if(roomLabel) roomLabel.textContent=roomId||'—';
+      if(!roomId){ if(clientStatusEl) clientStatusEl.textContent='缺少房間代碼，請重新掃描 QR Code。'; return; }
+      if(!window.Peer){ if(clientStatusEl) clientStatusEl.textContent='行動控制模組載入失敗，請稍後再試。'; if(clientJoinCardEl) clientJoinCardEl.style.display='none'; return; }
+      if(clientJoinBtnEl) clientJoinBtnEl.disabled=true;
+      showClientMessage('');
+      const peer=new Peer(undefined,{debug:2});
+      clientContext.peer=peer;
+      if(clientStatusEl) clientStatusEl.textContent='正在嘗試連線…';
+      peer.on('open',()=>{
+        if(clientStatusEl) clientStatusEl.textContent='已連線，等待主機回應…';
+        const conn=peer.connect(`alco-${normalizeRoomId(roomId)}`,{reliable:true});
+        clientContext.conn=conn;
+        conn.on('open',()=>{
+          if(clientStatusEl) clientStatusEl.textContent='連線成功，請輸入暱稱加入。';
+          if(clientJoinBtnEl) clientJoinBtnEl.disabled=false;
+        });
+        conn.on('data',handleHostMessage);
+        conn.on('close',()=>{
+          if(clientStatusEl) clientStatusEl.textContent='與主機連線中斷。';
+          clientContext.conn=null;
+          clientContext.joined=false;
+          clientContext.playerId=null;
+          if(clientJoinCardEl) clientJoinCardEl.style.display='block';
+          if(clientJoinBtnEl) clientJoinBtnEl.disabled=false;
+          if(clientControlsEl) clientControlsEl.style.display='none';
+          showClientMessage('');
+        });
+        conn.on('error',err=>{ if(clientStatusEl) clientStatusEl.textContent='連線錯誤：'+(err&&err.message?err.message:err); });
+      });
+      peer.on('error',err=>{ if(clientStatusEl) clientStatusEl.textContent='建立連線失敗：'+(err&&err.message?err.message:err); });
+      setupClientControls();
+    }
+
+    function showClientMessage(text,type='info'){
+      if(!clientMessageEl) return;
+      clientMessageEl.textContent=text||'';
+      clientMessageEl.style.color=type==='error'?'#ff9b9b':'var(--muted)';
+    }
+
+    function updateClientState(data){
+      if(!data) return;
+      if(data.roomId && !roomId) roomId=data.roomId;
+      if(clientTurnNameEl){
+        const active=data.players.find(p=>p.id===data.activePlayerId);
+        clientTurnNameEl.textContent=active?active.name:'—';
+      }
+      if(clientDiceInfoEl) clientDiceInfoEl.textContent=`骰子：${data.dice||'—'}`;
+      if(clientPlayersEl){
+        clientPlayersEl.innerHTML='';
+        data.players.forEach(p=>{
+          const item=el('div','item');
+          item.style.border=p.id===data.activePlayerId?'1px solid var(--accent)':'1px solid rgba(255,255,255,.08)';
+          item.style.background=p.id===clientContext.playerId?'rgba(138,198,255,.15)':'rgba(26,36,56,.6)';
+          if(p.avatar){
+            const img=el('img','player-avatar');
+            img.src=p.avatar; img.alt=p.name;
+            item.appendChild(img);
+          } else {
+            const dot=el('div','player-dot');
+            dot.style.background=p.color;
+            item.appendChild(dot);
+          }
+          const info=el('div','',`<b>${p.name}</b><div style="font-size:12px;color:var(--muted)">位置 ${p.pos}</div>`);
+          item.appendChild(info);
+          clientPlayersEl.appendChild(item);
+        });
+        if(clientPlayersCardEl) clientPlayersCardEl.style.display=data.players.length?'block':'none';
+      }
+      if(clientLogEl){
+        clientLogEl.innerHTML='';
+        (data.logs||[]).forEach(msg=>{ const item=el('div','',msg); clientLogEl.appendChild(item); });
+        if(clientLogCardEl) clientLogCardEl.style.display=(data.logs&&data.logs.length)?'block':'none';
+      }
+      const me=data.players.find(p=>p.id===clientContext.playerId);
+      if(clientPosEl) clientPosEl.textContent=me?me.pos:'—';
+      if(clientControlsEl) clientControlsEl.style.display=clientContext.joined?'block':'none';
+      if(clientRollBtn) clientRollBtn.disabled = !(me && data.activePlayerId===me.id && !data.waitingEnd);
+      if(clientEndBtn) clientEndBtn.disabled = !(me && data.activePlayerId===me.id && data.waitingEnd);
+      if(!me && clientContext.joined){
+        clientContext.joined=false;
+        clientContext.playerId=null;
+        if(clientJoinCardEl) clientJoinCardEl.style.display='block';
+        if(clientJoinBtnEl) clientJoinBtnEl.disabled=false;
+        showClientMessage('你已不在遊戲中，可重新加入。','error');
+      }
+    }
+
+    async function readAvatarFile(file){
+      if(!file) return null;
+      if(file.size>1024*1024) throw new Error('圖片需小於 1 MB');
+      const dataUrl=await new Promise((resolve,reject)=>{
+        const reader=new FileReader();
+        reader.onload=()=>resolve(reader.result);
+        reader.onerror=()=>reject(new Error('無法讀取圖片'));
+        reader.readAsDataURL(file);
+      });
+      return await new Promise((resolve,reject)=>{
+        const img=new Image();
+        img.onload=()=>{
+          const maxSide=256;
+          const scale=Math.min(1,maxSide/Math.max(img.width,img.height));
+          const canvas=document.createElement('canvas');
+          canvas.width=Math.max(1,Math.round(img.width*scale));
+          canvas.height=Math.max(1,Math.round(img.height*scale));
+          const ctx=canvas.getContext('2d');
+          ctx.drawImage(img,0,0,canvas.width,canvas.height);
+          resolve(canvas.toDataURL('image/jpeg',0.85));
+        };
+        img.onerror=()=>reject(new Error('無法處理圖片'));
+        img.src=dataUrl;
+      });
+    }
+
+    function setupClientControls(){
+      if(clientJoinBtnEl){
+        clientJoinBtnEl.onclick=async()=>{
+          if(!clientContext.conn||!clientContext.conn.open){ showClientMessage('尚未與主機連線','error'); return; }
+          const name=clientNameInputEl ? clientNameInputEl.value.trim() : '';
+          if(!name){ showClientMessage('請輸入暱稱','error'); return; }
+          clientJoinBtnEl.disabled=true;
+          showClientMessage('正在加入…');
+          try{
+            const avatarData = clientAvatarInputEl && clientAvatarInputEl.files && clientAvatarInputEl.files[0] ? await readAvatarFile(clientAvatarInputEl.files[0]) : null;
+            clientContext.conn.send({type:'join',name,avatar:avatarData});
+          }catch(err){
+            showClientMessage(err.message||'加入失敗','error');
+            clientJoinBtnEl.disabled=false;
+          }
+        };
+      }
+      if(clientRollBtn){
+        clientRollBtn.onclick=()=>{
+          if(clientContext.conn&&clientContext.conn.open&&clientContext.playerId){
+            clientContext.conn.send({type:'roll',playerId:clientContext.playerId});
+            clientRollBtn.disabled=true;
+          }
+        };
+      }
+      if(clientEndBtn){
+        clientEndBtn.onclick=()=>{
+          if(clientContext.conn&&clientContext.conn.open&&clientContext.playerId){
+            clientContext.conn.send({type:'endTurn',playerId:clientContext.playerId});
+          }
+        };
+      }
+    }
+
+    function handleHostMessage(msg){
+      if(!msg||typeof msg!=='object') return;
+      switch(msg.type){
+        case 'state':
+          updateClientState(msg.payload);
+          break;
+        case 'joined':
+          clientContext.joined=true;
+          clientContext.playerId=msg.playerId;
+          if(clientStatusEl) clientStatusEl.textContent='加入成功，請等待輪到你。';
+          if(clientJoinCardEl) clientJoinCardEl.style.display='none';
+          if(clientJoinBtnEl) clientJoinBtnEl.disabled=false;
+          showClientMessage('加入成功！');
+          break;
+        case 'error':
+          showClientMessage(msg.message||'加入失敗','error');
+          if(clientJoinBtnEl) clientJoinBtnEl.disabled=false;
+          break;
+        case 'info':
+          showClientMessage(msg.message||'');
+          break;
+        case 'removed':
+          clientContext.joined=false;
+          clientContext.playerId=null;
+          if(clientStatusEl) clientStatusEl.textContent='你已被移出遊戲，可重新加入。';
+          if(clientJoinCardEl) clientJoinCardEl.style.display='block';
+          if(clientJoinBtnEl) clientJoinBtnEl.disabled=false;
+          if(clientControlsEl) clientControlsEl.style.display='none';
+          showClientMessage('你已被移出遊戲，可重新加入。','error');
+          break;
+        default:
+          break;
+      }
+    }
+
+    function setupNetworking(){
+      if(isHostMode) setupHostNetworking();
+      else setupClientNetworking(joinCodeParam||'');
     }
 
     // 編輯器
@@ -453,9 +1028,20 @@
     // 存檔/讀檔（含遊戲卡池）
     $('#btnExportSave').onclick = e=>{ const save={ players: state.players.map(p=>({name:p.name,color:p.color,pos:p.pos,sips:p.sips,totalSips:p.totalSips,skip:p.skip,buff:p.buff})), turn: state.turn, cfg, chance: state.chance, destiny: state.destiny, game: state.game, waitingEnd: state.waitingEnd }; const blob=new Blob([JSON.stringify(save,null,2)],{type:'application/json'}); const url=URL.createObjectURL(blob); e.target.href=url; e.target.download='alcohol-monopoly-save.json'; };
     $('#btnImportSave').onclick=()=>$('#importSave').click();
-    $('#importSave').onchange = ev=>{ const f=ev.target.files[0]; if(!f) return; const rd=new FileReader(); rd.onload=()=>{ try{ const data=JSON.parse(rd.result); cfg=data.cfg||cfg; state.players=[]; (data.players||[]).forEach(p=>addPlayer(p.name)); state.players.forEach((p,i)=>{ const d=data.players[i]; p.pos=d.pos; p.sips=d.sips||0; p.totalSips=d.totalSips||0; p.skip=d.skip||false; p.buff=d.buff||0; }); state.turn=data.turn||0; state.chance=data.chance||[]; state.destiny=data.destiny||[]; state.game=data.game||[]; state.waitingEnd=!!data.waitingEnd; buildBoard(); placePawns(); renderPlayers(); refreshTurnInfo(); updateControls(); log('已載入存檔'); }catch(err){ alert('載入失敗') } }; rd.readAsText(f) };
+    $('#importSave').onchange = ev=>{ const f=ev.target.files[0]; if(!f) return; const rd=new FileReader(); rd.onload=()=>{ try{ const data=JSON.parse(rd.result); cfg=data.cfg||cfg; playerConnections.forEach(conn=>{ try{ conn.send({type:'info',message:'主機已載入新存檔，請重新加入。'}); }catch(e){} conn.playerId=null; }); playerConnections.clear(); state.players=[]; (data.players||[]).forEach(p=>addPlayer(p.name,{silent:true})); state.players.forEach((p,i)=>{ const d=data.players[i]||{}; p.pos=d.pos||0; p.sips=d.sips||0; p.totalSips=d.totalSips||0; p.skip=d.skip||false; p.buff=d.buff||0; p.avatar=d.avatar||null; p.remote=false; p.connectionId=null; }); state.turn=data.turn||0; state.chance=data.chance||[]; state.destiny=data.destiny||[]; state.game=data.game||[]; state.waitingEnd=!!data.waitingEnd; buildBoard(); placePawns(); renderPlayers(); refreshTurnInfo(); updateControls(); updateRemoteStatus(); log('已載入存檔'); }catch(err){ alert('載入失敗') } }; rd.readAsText(f) };
 
-    function log(t){ const it=el('div','item', new Date().toLocaleTimeString()+" · "+t); $('#log').prepend(it) }
+    function log(t){
+      const message=new Date().toLocaleTimeString()+" · "+t;
+      const box=$('#log');
+      if(box){
+        const it=el('div','item',message);
+        box.prepend(it);
+        while(box.children.length>MAX_LOG_HISTORY) box.removeChild(box.lastChild);
+      }
+      logHistory.unshift(message);
+      if(logHistory.length>MAX_LOG_HISTORY) logHistory.splice(MAX_LOG_HISTORY);
+      syncState();
+    }
     function updateControls(){ $('#roll').disabled = state.waitingEnd || state.anim || state.moving || state.players.length===0; $('#endTurn').disabled = !state.waitingEnd || state.players.length===0; $('#undoBtn').disabled = H.length===0; }
 
     $('#addPlayer').onclick=()=>{ addPlayer($('#playerName').value.trim()); $('#playerName').value=''; };
@@ -467,6 +1053,7 @@
 
     function init(){ buildBoard(); $('#chancePeek').textContent=`${DEFAULT.chance.length} 張（洗牌後抽取）`; $('#destinyPeek').textContent=`${DEFAULT.destiny.length} 張（洗牌後抽取）`; $('#gamePeek').textContent=`${DEFAULT.game.length} 張（洗牌後抽取）`; refreshTurnInfo(); updateControls(); log('啟動遊戲'); }
     init();
+    setupNetworking();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- improve the host layout for small screens and add QR-based join instructions plus a dedicated mobile control panel
- integrate PeerJS networking so phones can join via QR code, send names/avatars, and roll or end turns remotely with synchronized state updates

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4e445d6d8832d9dfa2ee6cfc12212